### PR TITLE
Added a check to ensure the insert_id is an integer looking thing.

### DIFF
--- a/bitpay/bp_lib.php
+++ b/bitpay/bp_lib.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2011-2015 BitPay
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,17 +26,17 @@
 require_once 'bp_options.php';
 
 function bpCurl($url, $apiKey, $post = false) {
-	global $bpOptions;	
-		
+	global $bpOptions;
+
 	$curl = curl_init($url);
 	$length = 0;
 	if ($post)
-	{	
+	{
 		curl_setopt($curl, CURLOPT_POST, 1);
 		curl_setopt($curl, CURLOPT_POSTFIELDS, $post);
 		$length = strlen($post);
 	}
-	
+
 	$uname = base64_encode($apiKey);
 	$header = array(
 		'Content-Type: application/json',
@@ -54,9 +54,9 @@ function bpCurl($url, $apiKey, $post = false) {
 	curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 	curl_setopt($curl, CURLOPT_FORBID_REUSE, 1);
 	curl_setopt($curl, CURLOPT_FRESH_CONNECT, 1);
-		
+
 	$responseString = curl_exec($curl);
-	
+
 	if($responseString == false) {
 		$response = curl_error($curl);
 	} else {
@@ -65,43 +65,43 @@ function bpCurl($url, $apiKey, $post = false) {
 	curl_close($curl);
 	return $response;
 }
-// $orderId: Used to display an orderID to the buyer. In the account summary view, this value is used to 
+// $orderId: Used to display an orderID to the buyer. In the account summary view, this value is used to
 // identify a ledger entry if present.
 //
-// $price: by default, $price is expressed in the currency you set in bp_options.php.  The currency can be 
+// $price: by default, $price is expressed in the currency you set in bp_options.php.  The currency can be
 // changed in $options.
 //
 // $posData: this field is included in status updates or requests to get an invoice.  It is intended to be used by
 // the merchant to uniquely identify an order associated with an invoice in their system.  Aside from that, Bit-Pay does
 // not use the data in this field.  The data in this field can be anything that is meaningful to the merchant.
 //
-// $options keys can include any of: 
+// $options keys can include any of:
 // ('itemDesc', 'itemCode', 'notificationEmail', 'notificationURL', 'redirectURL', 'apiKey'
-//		'currency', 'physical', 'fullNotifications', 'transactionSpeed', 'buyerName', 
+//		'currency', 'physical', 'fullNotifications', 'transactionSpeed', 'buyerName',
 //		'buyerAddress1', 'buyerAddress2', 'buyerCity', 'buyerState', 'buyerZip', 'buyerEmail', 'buyerPhone')
 // If a given option is not provided here, the value of that option will default to what is found in bp_options.php
 // (see api documentation for information on these options).
-function bpCreateInvoice($orderId, $price, $posData, $options = array()) {	
-	global $bpOptions;	
-	
+function bpCreateInvoice($orderId, $price, $posData, $options = array()) {
+	global $bpOptions;
+
 	$options = array_merge($bpOptions, $options);	// $options override any options found in bp_options.php
-	
+
 	$options['posData'] = '{"posData": "' . $posData . '"';
 	if ($bpOptions['verifyPos']) // if desired, a hash of the POS data is included to verify source in the callback
 		$options['posData'].= ', "hash": "' . crypt($posData, $options['apiKey']).'"';
-	$options['posData'].= '}';	
-	
+	$options['posData'].= '}';
+
 	$options['orderID'] = $orderId;
 	$options['price'] = $price;
-	
-	$postOptions = array('orderID', 'itemDesc', 'itemCode', 'notificationEmail', 'notificationURL', 'redirectURL', 
-		'posData', 'price', 'currency', 'physical', 'fullNotifications', 'transactionSpeed', 'buyerName', 
+
+	$postOptions = array('orderID', 'itemDesc', 'itemCode', 'notificationEmail', 'notificationURL', 'redirectURL',
+		'posData', 'price', 'currency', 'physical', 'fullNotifications', 'transactionSpeed', 'buyerName',
 		'buyerAddress1', 'buyerAddress2', 'buyerCity', 'buyerState', 'buyerZip', 'buyerEmail', 'buyerPhone');
 	foreach($postOptions as $o)
 		if (array_key_exists($o, $options))
 			$post[$o] = $options[$o];
 	$post = json_encode($post);
-	
+
 	$response = bpCurl('https://bitpay.com/api/invoice/', $options['apiKey'], $post);
 
 	return $response;
@@ -111,25 +111,25 @@ function bpCreateInvoice($orderId, $price, $posData, $options = array()) {
 function bpVerifyNotification($apiKey = false) {
 	global $bpOptions;
 	if (!$apiKey)
-		$apiKey = $bpOptions['apiKey'];		
-	
+		$apiKey = $bpOptions['apiKey'];
+
 	$post = file_get_contents("php://input");
 	if (!$post)
 		return 'No post data';
-		
+
 	$json = json_decode($post, true);
-	
+
 	if (is_string($json))
 		return $json; // error
 
-	if (!array_key_exists('posData', $json)) 
+	if (!array_key_exists('posData', $json))
 		return 'no posData';
-		
+
 	$posData = json_decode($json['posData'], true);
-	if($bpOptions['verifyPos'] and $posData['hash'] != crypt($posData['posData'], $apiKey)) 
+	if($bpOptions['verifyPos'] and $posData['hash'] != crypt($posData['posData'], $apiKey))
 		return 'authentication failed (bad hash)';
 	$json['posData'] = $posData['posData'];
-		
+
 	if (!array_key_exists('id', $json))
         {
             return 'Cannot find invoice ID';
@@ -142,17 +142,13 @@ function bpVerifyNotification($apiKey = false) {
 function bpGetInvoice($invoiceId, $apiKey=false) {
 	global $bpOptions;
 	if (!$apiKey)
-		$apiKey = $bpOptions['apiKey'];		
+		$apiKey = $bpOptions['apiKey'];
 
 	$response = bpCurl('https://bitpay.com/api/invoice/'.$invoiceId, $apiKey);
 	if (is_string($response))
 		return $response; // error
 	$response['posData'] = json_decode($response['posData'], true);
-	if($bpOptions['verifyPos'])
-        {
-            $response['posData'] = $response['posData']['posData'];
-        }
-	return $response;	
+	return $response;
 }
 
 ?>

--- a/bitpay_callback.php
+++ b/bitpay_callback.php
@@ -2,19 +2,19 @@
 
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2011-2015 BitPay
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 require 'bitpay/bp_lib.php';
 require 'includes/application_top.php';
 
@@ -37,18 +37,30 @@ function bplog($contents) {
     }
 }
 
-$response = bpVerifyNotification(MODULE_PAYMENT_BITPAY_APIKEY);
+function validateResponse($response, $keys) {
+    if (is_array($response) &&
+        array_key_exists($keys[0], $response) &&
+        array_key_exists($keys[0], $response[$keys[0]]) &&
+        preg_match('/^\d+$/', $response[$keys[0]][$keys[0]]) &&
+        array_key_exists($keys[1], $response)) {
+        return true;
+    }
+    return false;
+}
 
-if (true === is_string($response)) {
+$response = bpVerifyNotification(MODULE_PAYMENT_BITPAY_APIKEY);
+$keys = array('posData', 'status');
+
+if (!validateResponse($response, $keys)) {
     bplog(date('H:i') . " bitpay callback error: " . $response . "\n");
 } else {
     global $db;
-    $order_id = $response['posData'];
-
-    switch ($response['status']) {
-        case 'confirmed':    
+    $order_id = $response[$keys[0]][$keys[0]];
+    $status = $response[$keys[1]];
+    switch ($status) {
+        case 'confirmed':
         case 'complete':
-            $db->Execute("update ". TABLE_ORDERS. " set orders_status = " . MODULE_PAYMENT_BITPAY_PAID_STATUS_ID . " where orders_id = ". intval($order_id));      
+            $db->Execute("update ". TABLE_ORDERS. " set orders_status = " . MODULE_PAYMENT_BITPAY_PAID_STATUS_ID . " where orders_id = ". intval($order_id));
             break;
         case 'expired':
             if (true === function_exists('zen_remove_order')) {

--- a/includes/modules/payment/bitpay.php
+++ b/includes/modules/payment/bitpay.php
@@ -128,6 +128,12 @@ class bitpay {
   // called upon clicking confirm (after before_process and after the order is created)
   function after_process() {
     global $insert_id, $order, $db;
+
+    //$insert_id must resemble an integer or else we can't match it into the db
+    if (!preg_match('/^\d+$/', $insert_id)) {
+        $this->log('after_process(). The $insert_id global is not set properly! Please ensure that: includes/modules/checkout_process.php properly sets $insert_id.');
+        throw new Exception('payment method failed');
+    }
     require_once 'bitpay/bp_lib.php';          
         
     // change order status to value selected by merchant


### PR DESCRIPTION
addresses #17 

I can't say why the $insert_id isn't set when the bitpay after_process function is called, but this appears to be the way other methods do things. For example, Authorize.net binds this value to orderID for the order status history. If the $insert_id global isn't set, then this record would not get inserted into the order status history because this field does not allow nulls.

Bottom line, if zencart does not give BitPay a proper order id, I am not sure there is much we can do about it.